### PR TITLE
added the ability to manually allow an action/page  be viewed directl…

### DIFF
--- a/cjax/ajax.php
+++ b/cjax/ajax.php
@@ -38,6 +38,11 @@ if(!defined('AJAX_FILE')) {
  * //@ajax_php;
  **/
 class ajax  {
+
+    public static function allowAction($controller, $action = null)
+    {
+        CoreEvents::allowAction($controller, $action);
+    }
 	
 	function __construct($controller)
 	{
@@ -138,11 +143,25 @@ class ajax  {
 			header("Status: 404 Not Found");
 			$this->abort("Controller Method/Function: {$raw_class}::{$function}() was not found");
 		}
+
+        try {
+
+            CoreEvents::verifyAction($raw_class, $function);
+
+        } catch (Exception $e) {
+
+            $this->abort($e->getMessage());
+        }
+
 		return $this->_response( call_user_func_array(array($requestObject, $function), $args) );
 	}
 	
 	function abort($err)
 	{
+        if(!ajax()->isAjaxRequest()) {
+            print $err;
+            die(0);
+        }
 		ajax()->error($err, 10);
 		exit(0);
 	}

--- a/cjax/core/classes/cjax.class.php
+++ b/cjax/core/classes/cjax.class.php
@@ -280,32 +280,43 @@ class CJAX_FRAMEWORK Extends CoreEvents {
 
 		$_options = (isset($url[3])) ? $url[3] : null;
 
-		$_params = null;
-		if ($params && !is_array($params)) {
-			$params = array($params);
-		}
-		if ($params) {
-
-			foreach ($params as $v) {
-				$_params[] = '|' . $v . '|';
-			}
-			$_params = '/' . implode('/', $_params);
-		}
-
-		if ($_options) {
-			//merged any passed options, this gets pulled back and sent to ajax options.
-			$options = array_merge($options, $_options);
-		}
+        $_params = null;
+        if ($params && !is_array($params)) {
+            $params = array($params);
+        }
 
 
+        //if it comes from call() or form() it will always be empty
+        //so it must be coming from route()
+        if($options) {
+            $_params = '/' . implode('/', $options);
+        } else {
 
-		if(!$f = ajax()->config->ajax_file) {
-			if (strpos($controller, ':') !== false) {
-				$parts = explode(':', $controller);
-				$path = $parts[1];
-				$controller = $parts[0];
+            if ($params) {
 
-				$f = $path . '/ajax.php';
+                foreach ($params as $v) {
+                    $_params[] = '|' . $v . '|';
+                }
+                $_params = '/' . implode('/', $_params);
+            }
+
+            if ($_options) {
+                //merged any passed options, this gets pulled back and sent to ajax options.
+                $options = array_merge($options, $_options);
+            }
+        }
+
+
+        $ajax = ajax();
+
+
+        if(!$f = $ajax->config->ajax_file) {
+            if(strpos($controller,':') !== false) {
+                $parts = explode(':', $controller);
+                $path  = $parts[1];
+                $controller = $parts[0];
+
+                $f = $path . '/ajax.php';
 
 			} else {
 
@@ -683,7 +694,6 @@ class CJAX_FRAMEWORK Extends CoreEvents {
 		}
 
 		return $this->xml($data);
-		return $this->xmlItem($this->xml($data), 'import') ;
 	}
 
 	/**

--- a/cjax/core/classes/core.class.php
+++ b/cjax/core/classes/core.class.php
@@ -246,6 +246,46 @@ class CoreEvents extends cjaxFormat {
 	public $_flag = null;
 	public $_flag_count = 0;
 
+    //give special direct access to a router action from within  controller
+    public static $allowActions = array();
+
+    public $verifyAction = array();
+
+    public static function allowAction($controller, $action = null)
+    {
+        $controller = strtolower($controller);
+        $action = strtolower($action);
+
+        self::$allowActions[$controller][] = $action;
+    }
+
+    public static function verifyAction($controller, $action, $engage = false)
+    {
+        $ajax = ajax();
+        if($engage) {
+            return $ajax->verifyAction[strtolower($controller)] = strtolower($action);
+        }
+
+        if(!$ajax->verifyAction) {
+            return true;
+        }
+
+        foreach(self::$allowActions as $k => $v) {
+            //check controller
+
+            if(!array_key_exists($k , $ajax->verifyAction)) {
+
+                Throw New Exception(sprintf('Action/Controller %s does not have view access to this page.', $controller));
+            }
+
+            if(implode($v) && !in_array($action, $v)) {
+
+                Throw New Exception(sprintf('Action: %s does not have view access to this page.', $action));
+            }
+        }
+        return true;
+    }
+
 	public function xmlItem($xml, $name)
 	{
 		if(!is_integer($xml)) {

--- a/cjax/core/preemptive.php
+++ b/cjax/core/preemptive.php
@@ -91,8 +91,22 @@ if(!$ajax->isAjaxRequest()) {
 
 	if(count(array_keys(debug_backtrace(false))) == 2) {
 
-		if(!defined('AJAX_VIEW') && !in_array($controller, $allowed)) {
-			exit("Security Error. You cannot access this file directly.");
-		}
+        if(!defined('AJAX_VIEW') && !in_array($controller, $allowed)) {
+
+            if($controller = stristr($controller,':x', true)) {
+
+                $ajax->verifyAction($controller, $function, true);
+
+                $ajax->controller 	= 	$controller;
+                $_REQUEST['controller'] = $controller;
+                $_REQUEST['function'] = $function;
+                $_REQUEST['cjax'] = time();
+
+            } else {
+
+                exit("Security Error. You cannot access this file directly.");
+            }
+        }
+
 	}
 }


### PR DESCRIPTION
…y on the browser if specified in the controller by invoking allowAction::($controller, $action), or simply allowAction($controller) to allow the entire controller. This is specifically useful if you want to allow the view of a controller action on the browser, or download a file, or anything that may need direct browser view of an ajax action.